### PR TITLE
Update handling of recurse parameter to match Pinto > 0.093.

### DIFF
--- a/lib/Dist/Zilla/Plugin/Pinto/Add.pm
+++ b/lib/Dist/Zilla/Plugin/Pinto/Add.pm
@@ -156,13 +156,18 @@ sub release {
 
     for my $root ( @{ $self->live_roots } ) {
 
+        my @recurse_arg;
+        if ( $self->has_recurse ) {
+            @recurse_arg = ($self->recurse ? qw(-recurse) : qw(-no-recurse));
+        }
+
         my @args = (
             -root     => $root,
             -message  => "Added " . $archive->basename,
 
             $self->authenticate ? (-username => $self->username) : (),
             $self->authenticate ? (-password => $self->password) : (),
-            $self->has_recurse  ? (-recurse  => $self->recurse)  : (),
+            @recurse_arg,
             $self->has_author   ? (-author   => $self->author)   : (),
             $self->has_stack    ? (-stack    => $self->stack)    : (),
 

--- a/t/01-functional.t
+++ b/t/01-functional.t
@@ -236,6 +236,50 @@ subtest "Repo not responding -- partial release" => sub {
 
 #-----------------------------------------------------------------------------
 
+{
+    my @pinto_args;
+    no warnings qw(once redefine);
+    local *Dist::Zilla::Plugin::Pinto::Add::_run_pinto = sub {
+        @pinto_args = @_;
+        return (1, '');
+    };
+
+    subtest "Recurse param of 0 handled correctly" => sub {
+
+        my $root = build_repo;
+        my $tzil = build_tzil( [$plugin => {root => $root,
+                                            recurse => 0,}] );
+
+        lives_ok { $tzil->release };
+
+        is(grep(/^-no-recurse$/, @pinto_args), 1,
+           'recurse => 0 handled correctly');
+    };
+    subtest "Recurse param of 1 handled correctly" => sub {
+
+        my $root = build_repo;
+        my $tzil = build_tzil( [$plugin => {root => $root,
+                                            recurse => 1,}] );
+
+        lives_ok { $tzil->release };
+
+        is(grep(/^-recurse$/, @pinto_args), 1,
+           'recurse => 1 handled correctly');
+    };
+    subtest "Recurse param unspecified handled correctly" => sub {
+
+        my $root = build_repo;
+        my $tzil = build_tzil( [$plugin => {root => $root}] );
+
+        lives_ok { $tzil->release };
+
+        is(grep(/recurse/, @pinto_args), 0,
+           'no recurse param handled correctly');
+    };
+}
+
+#-----------------------------------------------------------------------------
+
 done_testing;
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
With 0.093, the command line parameter used to specify whether 'pinto
add' should recurse was changed to either '--recurse' or --no-recurse.

This commit updates the plugin and adds a set of tests that hijack
Dist::Zilla::Plugin::Pinto::Add::_run_pinto and confirm that it is
being specified correctly.
