### PR TITLE
Update copyright year to 2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Jeffrey Ryan Thalhammer <jeff@stratopan.com>
 
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2013 by Jeffrey Ryan Thalhammer.
+This software is copyright (c) 2014 by Jeffrey Ryan Thalhammer.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name             = Dist-Zilla-Plugin-Pinto-Add
 main_module      = lib/Dist/Zilla/Plugin/Pinto/Add.pm
 author           = Jeffrey Ryan Thalhammer <jeff@stratopan.com>
 copyright_holder = Jeffrey Ryan Thalhammer
-copyright_year   = 2013
+copyright_year   = 2014
 license          = Perl_5
 version          = 0.088
 


### PR DESCRIPTION
The current release (version 0.088) was released in March 2014, thus the
copyright year should be 2014.