### PR TITLE
Wrap long lines where possible in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ version 0.088
 
 # DESCRIPTION
 
-This is a release-stage plugin for [Dist::Zilla](https://metacpan.org/pod/Dist::Zilla) that will ship your
-distribution releases to a local or remote [Pinto](https://metacpan.org/pod/Pinto) repository.
+This is a release-stage plugin for [Dist::Zilla](https://metacpan.org/pod/Dist::Zilla)
+that will ship your distribution releases to a local or remote [Pinto](https://metacpan.org/pod/Pinto)
+repository.
 
 Before building the release, all repositories are checked for connectivity. If
 a repository is not responding you will be prompted to skip it or abort the
@@ -33,12 +34,13 @@ entire release.  If none of the repositories are responding, then the release
 will be aborted.  Any errors encountered while shipping to the remaining
 repositories will also cause the rest of the release to abort.
 
-__IMPORTANT:__ You need to install [Pinto](https://metacpan.org/pod/Pinto) to make this plugin work.  It ships
-separately so you can decide how you want to install it.  Peronally, I
-recommend installing Pinto as a stand-alone application as described in
-[Pinto::Manual::Installing](https://metacpan.org/pod/Pinto::Manual::Installing) and then setting the `PINTO_HOME` environment
-variable accordingly.  But you can also just install Pinto from CPAN using the
-usual tools.
+__IMPORTANT:__ You need to install [Pinto](https://metacpan.org/pod/Pinto)
+to make this plugin work.  It ships separately so you can decide how you
+want to install it.  Peronally, I recommend installing Pinto as a
+stand-alone application as described in
+[Pinto::Manual::Installing](https://metacpan.org/pod/Pinto::Manual::Installing)
+and then setting the `PINTO_HOME` environment variable accordingly.  But you
+can also just install Pinto from CPAN using the usual tools.
 
 # CONFIGURATION
 
@@ -49,11 +51,12 @@ configuration.
 
 - root = REPOSITORY
 
-    Specifies the root of the Pinto repository you want to ship to.  It can be
-    either a path to a local repository or a URI where [pintod](https://metacpan.org/pod/pintod) is listening. If
-    not specified, it defaults to the `PINTO_REPOSITORY_ROOT` environment
-    variable.  You can ship to multiple repositories by specifying the `root`
-    parameter multiple times.  See also ["USING MULTIPLE REPOSITORIES"](#using-multiple-repositories).
+    Specifies the root of the Pinto repository you want to ship to.  It can
+    be either a path to a local repository or a URI where
+    [pintod](https://metacpan.org/pod/pintod) is listening. If not specified, it
+    defaults to the `PINTO_REPOSITORY_ROOT` environment variable.  You can ship
+    to multiple repositories by specifying the `root` parameter multiple times.
+    See also ["USING MULTIPLE REPOSITORIES"](#using-multiple-repositories).
 
 - authenticate = 0|1
 
@@ -123,8 +126,9 @@ You can find documentation for this module with the perldoc command.
 
 ## Websites
 
-The following websites have more information about this module, and may be of help to you. As always,
-in addition to those websites please use your favorite search engine to discover more resources.
+The following websites have more information about this module, and may be
+of help to you. As always, in addition to those websites please use your
+favorite search engine to discover more resources.
 
 - MetaCPAN
 
@@ -134,7 +138,8 @@ in addition to those websites please use your favorite search engine to discover
 
 - CPAN Ratings
 
-    The CPAN Ratings is a website that allows community ratings and reviews of Perl modules.
+    The CPAN Ratings is a website that allows community ratings and reviews
+    of Perl modules.
 
     [http://cpanratings.perl.org/d/Dist-Zilla-Plugin-Pinto-Add](http://cpanratings.perl.org/d/Dist-Zilla-Plugin-Pinto-Add)
 
@@ -146,32 +151,37 @@ in addition to those websites please use your favorite search engine to discover
 
 - CPAN Testers
 
-    The CPAN Testers is a network of smokers who run automated tests on uploaded CPAN distributions.
+    The CPAN Testers is a network of smokers who run automated tests on
+    uploaded CPAN distributions.
 
     [http://www.cpantesters.org/distro/D/Dist-Zilla-Plugin-Pinto-Add](http://www.cpantesters.org/distro/D/Dist-Zilla-Plugin-Pinto-Add)
 
 - CPAN Testers Matrix
 
-    The CPAN Testers Matrix is a website that provides a visual overview of the test results for a distribution on various Perls/platforms.
+    The CPAN Testers Matrix is a website that provides a visual overview of
+    the test results for a distribution on various Perls/platforms.
 
     [http://matrix.cpantesters.org/?dist=Dist-Zilla-Plugin-Pinto-Add](http://matrix.cpantesters.org/?dist=Dist-Zilla-Plugin-Pinto-Add)
 
 - CPAN Testers Dependencies
 
-    The CPAN Testers Dependencies is a website that shows a chart of the test results of all dependencies for a distribution.
+    The CPAN Testers Dependencies is a website that shows a chart of the
+    test results of all dependencies for a distribution.
 
     [http://deps.cpantesters.org/?module=Dist::Zilla::Plugin::Pinto::Add](http://deps.cpantesters.org/?module=Dist::Zilla::Plugin::Pinto::Add)
 
 ## Internet Relay Chat
 
-You can get live help by using IRC ( Internet Relay Chat ). If you don't know what IRC is,
-please read this excellent guide: [http://en.wikipedia.org/wiki/Internet\_Relay\_Chat](http://en.wikipedia.org/wiki/Internet_Relay_Chat). Please
-be courteous and patient when talking to us, as we might be busy or sleeping! You can join
-those networks/channels and get help:
+You can get live help by using IRC ( Internet Relay Chat ). If you don't
+know what IRC is, please read this excellent guide:
+[http://en.wikipedia.org/wiki/Internet\_Relay\_Chat](http://en.wikipedia.org/wiki/Internet_Relay_Chat).
+Please be courteous and patient when talking to us, as we might be busy or
+sleeping! You can join those networks/channels and get help:
 
 - irc.perl.org
 
-    You can connect to the server at 'irc.perl.org' and join this channel: #pinto then talk to this person for help: thaljef.
+    You can connect to the server at 'irc.perl.org' and join this channel:
+    #pinto then talk to this person for help: thaljef.
 
 ## Bugs / Feature Requests
 
@@ -179,9 +189,9 @@ those networks/channels and get help:
 
 ## Source Code
 
-The code is open to the world, and available for you to hack on. Please feel free to browse it and play
-with it, or whatever. If you want to contribute patches, please send me a diff or prod me to pull
-from your repository :)
+The code is open to the world, and available for you to hack on. Please feel
+free to browse it and play with it, or whatever. If you want to contribute
+patches, please send me a diff or prod me to pull from your repository :)
 
 [https://github.com/thaljef/Dist-Zilla-Plugin-Pinto-Add](https://github.com/thaljef/Dist-Zilla-Plugin-Pinto-Add)
 


### PR DESCRIPTION
This is a purely cosmetic change, however most of the document seemed to be
written with a roughly 80 character width and thus to be consistent with
this style (and that it can be hard to read long lines on some terminals) it
could be a worthwhile improvement.

I can appreciate it if you don't wish to accept this PR; it is submitted in the hope that it helps :-)