### PR TITLE
Add indirect Dist::Zilla author prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,13 @@ File::Which                 = 0
 [Prereqs / TestRequires]
 Test::More                  = 0.96               ; for done_testing()
 
+; for section Support
+; authordep Pod::Weaver::Section::Support
+; for section Contributors
+; authordep Pod::Weaver::Section::Contributors
+; for section -StopWords
+; authordep Pod::Weaver::Plugin::StopWords
+
 [MinimumPerl]       ; determine minimum perl version
 [MetaNoIndex]       ; sets 'no_index' in META
 directory = t


### PR DESCRIPTION
On a fresh system, some Pod::Weaver modules can't be found, thus `dzil test
--author --release` will fail due to missing modules.  This change adds the
prerequisites to the author dependencies as documented by Dist::Zilla
(http://dzil.org/tutorial/prereq.html; in the section about Declaring Author
Prereqs).  It is thus now possible to install and test this plugin like so:

    $ dzil authordeps | cpanm --no-skip-satisfied
    $ dzil listdeps --author | cpanm --no-skip-satisfied
    $ dzil test --author --release

This PR is intended to be helpful; if there is anything I can do to improve it, or make it conform to your coding (etc.) standards, please let me know and I'll make the relevant changes and resubmit.