### PR TITLE
Add Travis-CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: perl
+
+perl:
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+before_install:
+    - curl -L http://getpinto.stratopan.com | bash
+    - source ~/opt/local/pinto/etc/bashrc
+
+install:
+    - dzil authordeps --missing | cpanm --no-skip-satisfied
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
This change adds a configuration for the travis-ci.org continuous integration service.  I've found from some testing that a given build has to be rerun in case it fails as sometimes an installation step (e.g. installing Pinto, or installing the authordeps or listdeps) fails in the middle, causing false negatives in some test runs.  Nevertheless, having Travis-CI watch over one's software can be very helpful and this is the spirit in which this PR has been submitted: i.e. it's hopefully helpful :-)