### PR TITLE
pass author on to pinto add

### DIFF
--- a/lib/Dist/Zilla/Plugin/Pinto/Add.pm
+++ b/lib/Dist/Zilla/Plugin/Pinto/Add.pm
@@ -182,6 +182,7 @@ sub _generate_pinto_args {
         $self->authenticate ? (-username => $self->username) : (),
         $self->authenticate ? (-password => $self->password) : (),
         $self->has_stack    ? (-stack    => $self->stack)    : (),
+        $self->has_author   ? (-author   => $self->author)   : (),
         @recurse_opt,
 
         $archive,


### PR DESCRIPTION
Hi!

Specifiying `author` in dist.ini has no effect, because the value is not passed on to `pinto add`. This patch fixes this bug (which might also be the problem behind issue #14)

Greetings,
domm